### PR TITLE
feat: creating a cache even on job task failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   using: 'node12'
   main: 'dist/restore/index.js'
   post: 'dist/save/index.js'
-  post-if: 'success()'
+  post-if: 'always()'
 branding:
   icon: 'archive'
   color: 'gray-dark'


### PR DESCRIPTION
Making sure the cache is always created when using this github action instead of only when all tasks succeed. This is useful in situations where a monorepo is being used because even if part of the job fails, the cache will still be created, which is especially true in instances where nx is used because it already only caches on successful runs. For example, a job with 3 cacheable tasks that succeed should not be penalized because the last task fails... (ie: If I am building 3 apps, and only one fails, the other 2 still have valid caches that should be useable...)